### PR TITLE
document some formats as officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ osgeo-importer is a Django application that helps you create custom pipelines fo
 `pip install git+https://github.com/GeoNode/django-osgeo-importer.git`
 
 
+## Supported geodata formats
+
+* Shapefile
+* KML
+* GeoJSON
+* GeoTIFF
+* GeoPackage
+* CSV
+* NITF
+
+These formats are officially supported, meaning that we make a public
+commitment to maintain support for them, including testing and maintenance to
+ensure they keep working. In particular, we will not make any changes to
+dependencies (like supported GDAL versions) which endangers support for these
+officially supported formats.
+
+
 ## Settings
 * `OSGEO_IMPORTER`: The default Importer to use for uploads.
 * `OSGEO_INSPECTOR`: The default Inspector to use for uploads.


### PR DESCRIPTION
I think we should commit to designate certain formats as officially supported, and by implication other formats as not supported (which doesn't mean they won't work, just that we reserve the right to break them if we are ever forced to).

Officially supported formats are default-whitelisted formats which we have tests for and which are in the default GDAL build, or which we can't find any realistic GDAL packages which don't support them (e.g. ubuntu, centos).

also tracked in Boundless JIRA as
https://issues.boundlessgeo.com:8443/browse/NODE-494