### PR TITLE
Ensure workspace exists before store creation.

### DIFF
--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -126,9 +126,10 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
                 self.catalog.delete(s)
                 msg = 'GeoGig is requested but not configured on geoserver instance, '\
                       'overriding connection "{}" with default "{}"'\
-                          .format(connection_string, default_connection_string)
+                      .format(connection_string, default_connection_string)
                 logger.warn(msg)
             layer_config['geoserver_store'] = default_connection_string
+            connection_string = default_connection_string
 
             try:
                 s = self.catalog.get_store(connection_string['name'])

--- a/osgeo_importer/tests/handlers/test_geoserver.py
+++ b/osgeo_importer/tests/handlers/test_geoserver.py
@@ -1,0 +1,43 @@
+# Needed to ignore 'geonode' name which appears in this package & grab the one we want.
+from __future__ import absolute_import
+from django.test import SimpleTestCase
+from geonode.geoserver.helpers import gs_catalog
+from osgeo_importer.handlers.geoserver import ensure_workspace_exists, GeoserverPublishHandler
+from geoserver.catalog import FailedRequestError
+
+
+class TestHandlerFunctions(SimpleTestCase):
+
+    def test_ensure_workspace_exists(self):
+        ws_name = 'nonexistent-workspace'
+        ws_namespace_uri = 'http://nonamespace.com'
+
+        # Check that the workspace doesn't exist
+        ws1 = gs_catalog.get_workspace(ws_name)
+        self.assertEqual(ws1, None)
+
+        ensure_workspace_exists(gs_catalog, ws_name, ws_namespace_uri)
+        # Check that the workspace now exists
+        ws2 = gs_catalog.get_workspace(ws_name)
+        self.assertNotEqual(ws2, None)
+
+        # Run again to ensure a preexisting workspace doesn't throw any exceptions
+        ensure_workspace_exists(gs_catalog, ws_name, ws_namespace_uri)
+
+
+class TestGeoserverPublishHandler(SimpleTestCase):
+
+    def test_get_or_create_datastore(self):
+        # --- Check that it creates a missing datastore
+        # No importer needed
+        importer = None
+        gph = GeoserverPublishHandler(importer)
+        connection_string = gph.get_default_store()
+        ds_name = connection_string['name']
+        # FailedRequestError indicates the data store couldn't be found
+        self.assertRaises(FailedRequestError, gs_catalog.get_store, ds_name)
+
+        layer_config = {'geoserver_store': connection_string}
+        gph.get_or_create_datastore(layer_config)
+        ds2 = gs_catalog.get_store(ds_name)
+        self.assertNotEqual(ds2, None)

--- a/osgeo_importer/tests/helpers.py
+++ b/osgeo_importer/tests/helpers.py
@@ -66,13 +66,14 @@ def works_with_geoserver(wrapped_func):
                 datastore = create_datastore(workspace_name, django_datastore, catalog)
 
                 # test method called here
-                ret = wrapped_func(self, *args, **kwargs)
-
-                # Tear down workspace/datastore as appropriate
-                if delete_ws:
-                    catalog.delete(ws, recurse=True)
-                else:
-                    catalog.delete(datastore, recurse=True)
+                try:
+                    ret = wrapped_func(self, *args, **kwargs)
+                finally:
+                    # Tear down workspace/datastore as appropriate
+                    if delete_ws:
+                        catalog.delete(ws, recurse=True)
+                    else:
+                        catalog.delete(datastore, recurse=True)
 
                 return ret
         else:

--- a/osgeo_importer/tests/test_utils.py
+++ b/osgeo_importer/tests/test_utils.py
@@ -9,8 +9,10 @@ from osgeo_importer.models import UploadedData
 from osgeo_importer.tests.helpers import works_with_geoserver
 from osgeo_importer.tests.test_settings import _TEST_FILES_DIR
 from osgeo_importer.utils import ImportHelper, import_all_layers
+import logging
 
 
+logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
@@ -23,36 +25,50 @@ class ImportUtilityTests(ImportHelper, TestCase,):
 
     @works_with_geoserver
     def test_import_all_layers(self):
-        # --- Upload
-        test_filename = 'boxes_plus_raster.gpkg'
-        expected_layer_count = 8
-        test_username = 'admin'
-        test_user = User.objects.get(username=test_username)
-        test_filepath = os.path.abspath(os.path.join(_TEST_FILES_DIR, test_filename))
+        test_filenames = [
+            'boxes_plus_raster.gpkg',
+            # Need to be added to testing files s3 bucket
+            # 'san_diego_downtown_generic-osm-data-20161202.gpkg',
+            # 'san_diego_downtown-osm-data-20161202.gpkg',
+            # 'san_diego_downtown-usgs-imagery-20161202.tight-bounds.gpkg',
+        ]
+        expected_layer_counts = [8]
+        # expected_layer_counts = [8, 3, 16, 1]
+        for test_filename, expected_layer_count in zip(test_filenames, expected_layer_counts):
+            logger.info('Checking "{}"'.format(test_filename))
+            # Drop the imported layers before checking each file to make counting them easier
+            Layer.objects.all().delete()
 
-        # Make temporary file (the upload/configure process removes the file & we want to keep our test file)
-        tmppath = os.path.join('/tmp', test_filename)
-        shutil.copyfile(test_filepath, tmppath)
+            # --- Upload
+            test_username = 'admin'
+            test_user = User.objects.get(username=test_username)
+            test_filepath = os.path.abspath(os.path.join(_TEST_FILES_DIR, test_filename))
 
-        # upload & configure_upload expect closed file objects
-        #    This is heritage from originally being closely tied to a view passing request.Files
-        of = open(tmppath, 'rb')
-        of.close()
-        files = [of]
-        upload = self.upload(files, self.admin_user)
-        self.configure_upload(upload, files)
+            # Make temporary file (the upload/configure process removes the file & we want to keep our test file)
+            tmppath = os.path.join('/tmp', test_filename)
+            shutil.copyfile(test_filepath, tmppath)
 
-        ud = UploadedData.objects.get(name=test_filename)
-        n_uploaded_layers = ud.uploadlayer_set.count()
-        self.assertEqual(
-            n_uploaded_layers, expected_layer_count,
-            'Expected {} uploaded layers from this file, found {}'.format(expected_layer_count, n_uploaded_layers)
-        )
+            # upload & configure_upload expect closed file objects
+            #    This is heritage from originally being closely tied to a view passing request.Files
+            of = open(tmppath, 'rb')
+            of.close()
+            files = [of]
+            upload = self.upload(files, self.admin_user)
+            self.configure_upload(upload, files)
 
-        import_all_layers(ud, owner=test_user)
+            ud = UploadedData.objects.get(name=test_filename)
+            n_uploaded_layers = ud.uploadlayer_set.count()
+            self.assertEqual(
+                n_uploaded_layers, expected_layer_count,
+                'Expected {} uploaded layers from file "{}", found {}'
+                .format(expected_layer_count, test_filename, n_uploaded_layers)
+            )
 
-        n_imported_layers = Layer.objects.count()
-        self.assertEqual(
-            n_imported_layers, expected_layer_count,
-            'Expected {} imported layers from this file, found {}'.format(expected_layer_count, n_imported_layers)
-        )
+            import_all_layers(ud, owner=test_user)
+
+            n_imported_layers = Layer.objects.count()
+            self.assertEqual(
+                n_imported_layers, expected_layer_count,
+                'Expected {} imported layers from file "{}", found {}'
+                .format(expected_layer_count, test_filename, n_imported_layers)
+            )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,12 +27,12 @@ sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/prof
 
 if ["$TRAVIS" = true];
 then
-   sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.2
+   sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.3
 else
    sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
    sudo apt-get update
-   sudo apt-get -y install postgresql-9.3-postgis-2.2
+   sudo apt-get -y install postgresql-9.3-postgis-2.3
 fi
 
 sudo apt-get install -y python-dev python-lxml libxslt1-dev  libpq-dev


### PR DESCRIPTION
Previously if the workspace hadn't been manually created raster layers were accidentally saved to the default workspace but the UI still tried to serve them from workspace "geonode".

Additionally makes some changes to tests:
 - Test import_all_layers prepped for testing more than one file.
 - @works_with_geoserver updated to clean up in the case of a test error.
