### PR TITLE
Add TMS Link in mapproxy publish handler.

### DIFF
--- a/osgeo_importer/handlers/geonode/publish_handler.py
+++ b/osgeo_importer/handlers/geonode/publish_handler.py
@@ -42,7 +42,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):
         """
-        Adds a layer in GeoNode, after it has been added to Geoserver.
+        Adds a layer in GeoNode & adds layer_config['geonode_layer_id'] with id of new layer.
 
         Handler specific params:
         "layer_owner": Sets the owner of the layer.
@@ -97,6 +97,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
         }
 
         new_layer, created = Layer.objects.get_or_create(**new_layer_kwargs)
+        layer_config['geonode_layer_id'] = new_layer.id
 
         # *** It is unclear where the date/time attributes are being created as part of the
         # ***    above get_or_create().  It's probably a geoserver-specific save signal handler,

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -29,7 +29,6 @@ SITENAME = 'osgeo_importer_prj'
 IMPORT_HANDLERS = [
     # If GeoServer handlers are enabled, you must have an instance of geoserver running.
     # Warning: the order of the handlers here matters.
-#     'osgeo_importer.handlers.mapproxy.publish_handler.MapProxyGPKGTilePublishHandler',
     'osgeo_importer.handlers.FieldConverterHandler',
     'osgeo_importer.handlers.geoserver.GeoserverPublishHandler',
     'osgeo_importer.handlers.geoserver.GeoserverPublishCoverageHandler',
@@ -38,6 +37,7 @@ IMPORT_HANDLERS = [
     'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
     'osgeo_importer.handlers.geoserver.GenericSLDHandler',
     'osgeo_importer.handlers.geonode.GeoNodePublishHandler',
+#     'osgeo_importer.handlers.mapproxy.publish_handler.MapProxyGPKGTilePublishHandler',
     'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
     'osgeo_importer.handlers.geonode.GeoNodeMetadataHandler'
 ]
@@ -106,7 +106,10 @@ DATABASE_ROUTERS = ['osgeo_importer_prj.dbrouters.DefaultOnlyMigrations']
 # # === MapProxy settings
 # # This is the location to place additional configuration files for mapproxy to work from.
 # # Currently it is only to allow tiles from gpkg files to be served.
-# # MAPPROXY_CONFIG_DIR = '/var/lib/eventkit/mapproxy/apps'
-# MAPPROXY_CONFIG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'mapproxy_confdir'))
-# # Name of the mapproxy config file to create for tile gpkg files.
-# MAPPROXY_CONFIG_FILENAME = 'geonode.yaml'
+MAPPROXY_CONFIG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'mapproxy_confdir'))
+# Name of the mapproxy config file to create for tile gpkg files.
+MAPPROXY_CONFIG_FILENAME = 'geonode.yaml'
+# This is the base URL for MapProxy WMS services
+# URLs will look like this: /geonode/tms/1.0.0/<layer_name>/<grid_name>/0/0/0.png and a <grid_name> will be
+#    set as '<layer_name>_<projection_id>' (by conf_from_geopackage()).
+MAPPROXY_SERVER_LOCATION = 'http://localhost:8088/geonode/tms/1.0.0/{layer_name}/{grid_name}/'


### PR DESCRIPTION
The title says it all, when gpkg tile layers are imported a base link to access them via mapproxy will be stored in geonode's Link model.

I expect a corresponding change here: https://github.com/GeoNode/geonode/blob/master/geonode/base/models.py#L685
would be the best way to make this available to views/templates, but will wait on that until Jeff/Mila confirm how they want to access the links.
