### PR TITLE
Move development pip dependency installation from scripts to requirements.dev.txt.

### DIFF
--- a/docs/developer_notes.rst
+++ b/docs/developer_notes.rst
@@ -1,8 +1,8 @@
 Developer Notes
 ===============
 
-Quickstart
-----------
+Getting Started
+---------------
 * Run tests in the vagrant vm:
     #. vagrant up
     #. vagrant ssh
@@ -18,7 +18,17 @@ Quickstart
 * Run tests in a virtualenv on your machine (This does roughly the same thing as the VM setup):
     #. pip install -r requirements.txt
     #. pip install -r requirements.dev.txt
-    #. install gdal/ogr (see requirements.dev.txt for notes)
+    #. install gdal/ogr:
+        For gdal/ogr python bindings, the easiest method is to install the system-level package
+        and link to virtual env's site-packages.
+            * Ubuntu: install system-level package python-gdal and link the following to site-packages/:
+                *  /usr/lib/python2.7/dist-packages/GDAL-2.1.0.egg-info
+                *  /usr/lib/python2.7/dist-packages/gdal.py
+                *  /usr/lib/python2.7/dist-packages/gdalconst.py
+                *  /usr/lib/python2.7/dist-packages/osr.py
+                *  /usr/lib/python2.7/dist-packages/ogr.py
+                *  /usr/lib/python2.7/dist-packages/gdalnumeric.py
+                *  /usr/lib/python2.7/dist-packages/osgeo
     #. install postgres with postgis enabled:
         * Ubuntu:
             #. Add repo (swap "xenial" for "trusty" if that's what you're running)::
@@ -32,9 +42,14 @@ Quickstart
             #. Install::
             
                 apt-get install postgresql-9.3-postgis-2.3
-                
+    #. create project's postgis geostore:
+        #. sudo -u postgres psql 'CREATE ROLE osgeo WITH SUPERUSER PASSWORD("osgeo");'
+            * (Superuser is needed for postgis setup in database during automated testing)
+        #. sudo -u postgres psql 'CREATE DATABASE osgeo_importer_test WITH OWNER osgeo;'
+        #. sudo -u postgres psql 'GRANT ALL ON DATABASE osgeo_importer_test TO osgeo;'
+        #. sudo -u postgres psql osgeo_importer_test 'CREATE EXTENSION postgis;'
     #. install geoserver (based on scripts/install.sh)::
-
+    
         cd <your_geoserver_dir>
         wget -N http://central.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.0.v20161208/jetty-runner-9.4.0.v20161208.jar
         wget -N http://ares.boundlessgeo.com/geoserver/2.9.2/geoserver-2.9.2-latest-war.zip
@@ -50,7 +65,11 @@ Quickstart
 
         sudo systemctl start postgresql
         cd <your_geoserver_dir>; java -Xmx512m -XX:MaxPermSize=256m -Dorg.eclipse.jetty.server.webapp.parentLoaderPriority=true -jar jetty-runner-9.3.9.v20161208.jar --path /geoserver geoserver.war
-
+    
+    #. Migrate your Django databases::
+    
+        python manage.py migrate
+        
     #. Run your tests::
     
         cd <your_importer_dir>; python manage.py test osgeo_importer
@@ -60,4 +79,11 @@ Tips
 * If you're running in the VM but testing using a browser on the host machine note that
   the geoserver requests will target the host machine rather than the vm.  Either
   start an instance on your host machine or forward port 8080 to the vm.
+
+* If you're having trouble with a missing oath2_provider error on startup, these two dependencies
+  will resolve the issue for xenial (16.04).  If you install them on 14.04 you will suffer
+  migration conflicts::
+    
+    pip install django-oauth-toolkit
+    pip install django-cors-headers
 

--- a/docs/mapproxy_config.rst
+++ b/docs/mapproxy_config.rst
@@ -45,7 +45,7 @@ Django
 ------
 
 In your project settings you'll need to:
-  * add four global variables:
+  * add these global variables:
     * MAPPROXY_CONFIG_DIR - This is the full path to the directory where your mapproxy configuration files are located.
     * MAPPROXY_CONFIG_FILENAME - This is the name of the mapproxy configuration file that the importer will manage.
     * MAPPROXY_SERVER_LOCATION - This is the root URL for access to your MapProxy 'geonode' instance.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,9 +1,7 @@
 Django==1.8.15
 
-GeoNode==2.5.3
-
-# For gdal/ogr python bindings, install system-level package & link to virtual env
-# On Ubuntu, install system-level package python-gdal & link the following to virtual env:
+# For gdal/ogr python bindings, the easiest method is to install system-level package & link to virtual env.
+# On Ubuntu, install system-level package python-gdal & link the following to virtual env site-packages/:
 #  /usr/lib/python2.7/dist-packages/GDAL-2.1.0.egg-info
 #  /usr/lib/python2.7/dist-packages/gdal.py
 #  /usr/lib/python2.7/dist-packages/gdalconst.py
@@ -12,9 +10,19 @@ GeoNode==2.5.3
 #  /usr/lib/python2.7/dist-packages/gdalnumeric.py
 #  /usr/lib/python2.7/dist-packages/osgeo
 
-python-dateutil
-psycopg2
+
+git+https://github.com/mapproxy/mapproxy.git@eeb162ee0604#egg=MapProxy==1.10.0a
+
+# Install GeoNode latest master
+git+https://github.com/GeoNode/geonode.git#egg=GeoNode
+awscli
 numpy
+python-dateutil
+flake8
+coverage
+
+
+psycopg2
 
 # You'll also need to get PostGIS running on the project's database.
 # Make sure PostGIS is installed and after migrating the database run the following
@@ -32,5 +40,5 @@ numpy
 
 #Needed on my virtualenv but not in vagrant machine or travis, why?
 #I'm using ubuntu 16.04 while the other two are on 14.04.
-django-oauth-toolkit-fork
-django-cors-headers
+###django-oauth-toolkit-fork
+###django-cors-headers

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,36 @@
+Django==1.8.15
+
+GeoNode==2.5.3
+
+# For gdal/ogr python bindings, install system-level package & link to virtual env
+# On Ubuntu, install system-level package python-gdal & link the following to virtual env:
+#  /usr/lib/python2.7/dist-packages/GDAL-2.1.0.egg-info
+#  /usr/lib/python2.7/dist-packages/gdal.py
+#  /usr/lib/python2.7/dist-packages/gdalconst.py
+#  /usr/lib/python2.7/dist-packages/osr.py
+#  /usr/lib/python2.7/dist-packages/ogr.py
+#  /usr/lib/python2.7/dist-packages/gdalnumeric.py
+#  /usr/lib/python2.7/dist-packages/osgeo
+
+python-dateutil
+psycopg2
+numpy
+
+# You'll also need to get PostGIS running on the project's database.
+# Make sure PostGIS is installed and after migrating the database run the following
+#   on Ubuntu, or adapt as appropriate for your system:
+#sudo -u postgres createuser osgeo ... # Superuser for some tests.
+#sudo -u postgres psql 'CREATE DATABASE osgeo_importer_test WITH OWNER osgeo;'
+#psql -U osgeo osgeo_importer_test 'CREATE EXTENSION postgis;'
+
+#sudo -u postgres createlang plpgsql osgeo_importer_test
+#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/postgis.sql
+#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/postgis_comments.sql
+#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/spatial_ref_sys.sql
+#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/topology.sql
+#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/topology_comments.sql
+
+#Needed on my virtualenv but not in vagrant machine or travis, why?
+#I'm using ubuntu 16.04 while the other two are on 14.04.
+django-oauth-toolkit-fork
+django-cors-headers

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,44 +1,15 @@
 Django==1.8.15
-
-# For gdal/ogr python bindings, the easiest method is to install system-level package & link to virtual env.
-# On Ubuntu, install system-level package python-gdal & link the following to virtual env site-packages/:
-#  /usr/lib/python2.7/dist-packages/GDAL-2.1.0.egg-info
-#  /usr/lib/python2.7/dist-packages/gdal.py
-#  /usr/lib/python2.7/dist-packages/gdalconst.py
-#  /usr/lib/python2.7/dist-packages/osr.py
-#  /usr/lib/python2.7/dist-packages/ogr.py
-#  /usr/lib/python2.7/dist-packages/gdalnumeric.py
-#  /usr/lib/python2.7/dist-packages/osgeo
-
-
-git+https://github.com/mapproxy/mapproxy.git@eeb162ee0604#egg=MapProxy==1.10.0a
+psycopg2
 
 # Install GeoNode latest master
 git+https://github.com/GeoNode/geonode.git#egg=GeoNode
+
 awscli
 numpy
 python-dateutil
 flake8
 coverage
 
+git+https://github.com/mapproxy/mapproxy.git@eeb162ee0604#egg=MapProxy==1.10.0a
 
-psycopg2
-
-# You'll also need to get PostGIS running on the project's database.
-# Make sure PostGIS is installed and after migrating the database run the following
-#   on Ubuntu, or adapt as appropriate for your system:
-#sudo -u postgres createuser osgeo ... # Superuser for some tests.
-#sudo -u postgres psql 'CREATE DATABASE osgeo_importer_test WITH OWNER osgeo;'
-#psql -U osgeo osgeo_importer_test 'CREATE EXTENSION postgis;'
-
-#sudo -u postgres createlang plpgsql osgeo_importer_test
-#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/postgis.sql
-#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/postgis_comments.sql
-#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/spatial_ref_sys.sql
-#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/topology.sql
-#sudo -u postgres psql -d osgeo_importer_test -f /usr/share/postgresql/9.X/contrib/postgis-2.Y/topology_comments.sql
-
-#Needed on my virtualenv but not in vagrant machine or travis, why?
-#I'm using ubuntu 16.04 while the other two are on 14.04.
-###django-oauth-toolkit-fork
-###django-cors-headers
+# You will also need gdal/ogr.  See Developer Notes section of docs.

--- a/scripts/downloads.sh
+++ b/scripts/downloads.sh
@@ -7,7 +7,7 @@ wget -N http://ares.boundlessgeo.com/geoserver/${GS_VERSION}/geoserver-${GS_VERS
 wget -N http://build.geonode.org/geoserver/latest/geoserver.war
 wget -N https://s3.amazonaws.com/django-osgeo-importer/gdal-2.1.0-linux-bin.tar.gz
 
-pip install awscli
-sudo mkdir -p -m 777 importer-test-files
-aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
+#pip install awscli
+#sudo mkdir -p -m 777 importer-test-files
+#aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
 popd

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,25 +45,14 @@ sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
 
-# python
-pip install psycopg2
-
 if [ -n "$1" ]
  then
  cd $1
 fi
 
+# Python packages, requirements & additional development requirements
 pip install -r requirements.txt
-# MapProxy 1.10 isn't released yet, use master branch until it is.  This commit is HEAD of master at this time.
-pip install -e git+https://github.com/mapproxy/mapproxy.git@eeb162ee0604#egg=MapProxy==1.10.0a
-pip install -e git+https://github.com/GeoNode/geonode.git#egg=GeoNode
-
-pip install -e .
-pip install awscli
-pip install --upgrade  numpy
-pip install --upgrade python-dateutil
-pip install flake8
-pip install coverage
+pip install -r requirements.dev.txt
 
 sudo mkdir -p -m 777 importer-test-files
 aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files


### PR DESCRIPTION
Having a development requirements package helps improve visibility of which packages & versions tests use.
Makes set up of common development arrangements not using vagrant (docker, virtualenv) easier.
