### PR TITLE
Docker images for postgres & geoserver with docker-compose for developing from a virtualenv.

### DIFF
--- a/scripts/docker-dev/docker-compose.yaml
+++ b/scripts/docker-dev/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  postgres:
+    build: "postgres-postgis/"
+    image: "postgresql-postgis:9.3-2.3"
+    ports:
+     - "5432:5432"
+    expose:
+     - "5432"
+  geoserver:
+    build: "geoserver/"
+    image: "geoserver-host-postgres:2.9.2"
+    ports:
+     - "8080:8080"
+    links:
+     - postgres

--- a/scripts/docker-dev/geoserver/Dockerfile
+++ b/scripts/docker-dev/geoserver/Dockerfile
@@ -1,0 +1,8 @@
+# Provides this geoserver image with 'localhost' remapped to the host machine so db requests are made to host port 5432.
+from winsent/geoserver:2.9.2
+
+ENV TERM=linux
+
+COPY startup_extra.sh /opt/geoserver/bin/startup_extra.sh
+RUN chmod a+x /opt/geoserver/bin/startup_extra.sh
+CMD ["/opt/geoserver/bin/startup_extra.sh"]

--- a/scripts/docker-dev/geoserver/startup_extra.sh
+++ b/scripts/docker-dev/geoserver/startup_extra.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Redirecting container's 'localhost' to container host."
+
+# Since this docker container is for a developer using a virtualenv on the host, this is a bit of
+#   a hack so when a database with host 'localhost' in the project settings file
+#   has its config passed to geoserver it will reference the host the developer expects.
+HOST_IP=`ip route | grep default | awk '{ printf "%s",$3 }'`
+
+cat /etc/hosts | sed "s/127.0.0.1/$HOST_IP/" > /tmp/etc_hosts
+cp /tmp/etc_hosts /etc/hosts
+
+/opt/geoserver/bin/startup.sh

--- a/scripts/docker-dev/postgres-postgis/Dockerfile
+++ b/scripts/docker-dev/postgres-postgis/Dockerfile
@@ -1,0 +1,3 @@
+from mdillon/postgis:9.3
+
+COPY init-user-db.sh /docker-entrypoint-initdb.d/init-user-db.sh

--- a/scripts/docker-dev/postgres-postgis/init-user-db.sh
+++ b/scripts/docker-dev/postgres-postgis/init-user-db.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE USER osgeo WITH PASSWORD 'osgeo';
+    ALTER USER osgeo WITH SUPERUSER;
+    CREATE DATABASE osgeo WITH OWNER osgeo;
+    GRANT ALL PRIVILEGES ON DATABASE osgeo TO osgeo;
+EOSQL


### PR DESCRIPTION
Simple docker-compose.yaml & two Dockerfiles to run postgres and geoserver instances on standard ports.
Makes it easy and quick to reset these services and develop / test without configuring or polluting instances of these services on your development machine.
