### PR TITLE
Increase allowed length of UploadedData.name to accomodate longer filenames.

### DIFF
--- a/osgeo_importer/migrations/0010_auto_20170109_1401.py
+++ b/osgeo_importer/migrations/0010_auto_20170109_1401.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0009_mapproxycacheconfig'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='uploadeddata',
+            name='name',
+            field=models.CharField(max_length=250, null=True),
+        ),
+    ]

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -130,7 +130,7 @@ class UploadedData(models.Model):
     state = models.CharField(max_length=16)
     date = models.DateTimeField('date', auto_now_add=True)
     upload_dir = models.CharField(max_length=1000, null=True)
-    name = models.CharField(max_length=64, null=True)
+    name = models.CharField(max_length=250, null=True)
     complete = models.BooleanField(default=False)
     size = models.IntegerField(null=True, blank=True)
     metadata = models.TextField(null=True)


### PR DESCRIPTION
https://github.com/GeoNode/django-osgeo-importer/issues/80
