### PR TITLE
Give human-readable and unique names to imported layers.

### DIFF
--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -237,6 +237,7 @@ class GDALInspector(InspectorMixin):
                                  'subdataset_index': m,
                                  'path': raster_list[m][0],
                                  'layer_name': raster_list[m][0].split(':')[-1],
+                                 'layer_type': 'raster',
                                  'raster': True, 'driver': driver}
             description.append(layer_description)
 

--- a/osgeo_importer/migrations/0011_uploadlayer_layer_type.py
+++ b/osgeo_importer/migrations/0011_uploadlayer_layer_type.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0010_auto_20170109_1401'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='uploadlayer',
+            name='layer_type',
+            field=models.CharField(max_length=10, null=True),
+        ),
+    ]

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -214,6 +214,7 @@ class UploadLayer(models.Model):
     task_id = models.CharField(max_length=36, blank=True, null=True)
     feature_count = models.IntegerField(null=True, blank=True)
     layer_name = models.CharField(max_length=64, null=True)
+    layer_type = models.CharField(max_length=10, null=True)
 
     @property
     def file_name(self):

--- a/osgeo_importer/tests/test_utils.py
+++ b/osgeo_importer/tests/test_utils.py
@@ -5,7 +5,6 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from geonode.layers.models import Layer
-from osgeo_importer.models import UploadedData
 from osgeo_importer.tests.helpers import works_with_geoserver
 from osgeo_importer.tests.test_settings import _TEST_FILES_DIR
 from osgeo_importer.utils import ImportHelper, import_all_layers
@@ -53,18 +52,19 @@ class ImportUtilityTests(ImportHelper, TestCase,):
             of = open(tmppath, 'rb')
             of.close()
             files = [of]
+
             upload = self.upload(files, self.admin_user)
             self.configure_upload(upload, files)
+            upload.refresh_from_db()
 
-            ud = UploadedData.objects.get(name=test_filename)
-            n_uploaded_layers = ud.uploadlayer_set.count()
+            n_uploaded_layers = upload.uploadlayer_set.count()
             self.assertEqual(
                 n_uploaded_layers, expected_layer_count,
                 'Expected {} uploaded layers from file "{}", found {}'
                 .format(expected_layer_count, test_filename, n_uploaded_layers)
             )
 
-            import_all_layers(ud, owner=test_user)
+            import_all_layers(upload, owner=test_user)
 
             n_imported_layers = Layer.objects.count()
             self.assertEqual(

--- a/osgeo_importer/tests/tests_original.py
+++ b/osgeo_importer/tests/tests_original.py
@@ -228,7 +228,7 @@ class UploaderTests(TestCase):
 
         for upload_layer in upload_layers:
             for config in configs:
-                if config['upload_file_name'] == upload_layer.name:
+                if config['upload_file_name'] == os.path.basename(upload_layer.name):
                     payload = config['config']
                     url = '/importer-api/data-layers/{0}/configure/'.format(upload_layer.id)
                     response = client.post(

--- a/scripts/docker-dev/docker-compose.yaml
+++ b/scripts/docker-dev/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     environment:
      - POSTGRES_USER=osgeo
      - POSTGRES_PASSWORD=osgeo
-     - POSTGRES_DB=osgeo
+     - POSTGRES_DB=osgeo_importer_test
     ports:
      - "5432:5432"
     expose:


### PR DESCRIPTION
Mostly updates in utils to ensure that unique layer names are generated and stored in UploadLayers which are used as default names when layer name is not configured manually, such as for bulk import operations.
Some related changes to ensure layer_type is available in import_all_layers()

Unrelated minor change in docker-compose.yaml to match database name to name used in default settings file.
