### PR TITLE
Add WKT to EPSG Utility to Find EPSG Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,14 @@ the Importer's `import` method is sent to each handler which includes the config
 ### Importers
 Importers are Python classes that are responsible for opening incoming geospatial datasets (using one or many inspectors) and
 copying features to a target location - typically a PostGIS database.
+
+### Adding Support for Additional EPSG Codes
+If you have data sets with projections that are not currently supported by the EPSG codes in the Pyproj data directory,
+you can add additional EPSG codes.  Inside the scripts folder there is a file called epsg_extra with some examples
+of additional EPSG codes that we've added.  You can add any additional EPSG code with it's corresponding projection
+in that file using the same format as our examples.
+
+You'll need to copy that file to your Pyproj data directory, which by default is
+/usr/local/lib/python2.7/dist-packages/pyproj/data.  If your Pyproj data directory is in a different location, you may
+need to add the PROJECTION_SETTINGS settings variable in your own Django settings with the directory that you're using.
+

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -18,7 +18,8 @@ from .utils import (
     increment,
     increment_filename,
     raster_import,
-    decode
+    decode,
+    convert_wkt_to_epsg
 )  # noqa: F401
 
 
@@ -309,6 +310,8 @@ class OGRImport(Import):
                 # pass the srs authority code to handlers
                 if srs.AutoIdentifyEPSG() == 0:
                     layer_options['srs'] = '{0}:{1}'.format(srs.GetAuthorityName(None), srs.GetAuthorityCode(None))
+                else:
+                    layer_options['srs'] = convert_wkt_to_epsg(srs.ExportToWkt())
 
                 n = 0
                 while True:

--- a/osgeo_importer/tests/tests_original.py
+++ b/osgeo_importer/tests/tests_original.py
@@ -1275,6 +1275,18 @@ class UploaderTests(TestCase):
         feature_type = self.catalog.get_resource(result.name)
         self.assertEqual(feature_type.projection, 'EPSG:32635')
 
+    def test_houston_tx_annexations(self):
+        """Tests Shapefile with originally unsupported EPSG Code.
+        """
+        result = self.generic_import(
+            'HoustonTXAnnexations.zip',
+            configs=[
+                {'index': 0}
+            ]
+        )
+        feature_type = self.catalog.get_resource(result.name)
+        self.assertEqual(feature_type.projection, 'EPSG:2278')
+
     def test_gwc_handler(self):
         """Tests the GeoWebCache handler
         """

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -510,11 +510,13 @@ def import_all_layers(uploaded_data, owner=None):
     [ir.wait() for ir in import_results]
     return len(import_results)
 
+
 def convert_wkt_to_epsg(wkt, epsg_directory='/usr/share/proj/', forceProj4=False):
     """ Transform a WKT string to an EPSG code
         Arguments
         ---------
-        wkt: WKT (well known text) definition, you can generally pass this in using ExportToWkt() on a Spatial Reference System instance.
+        wkt: WKT (well known text) definition, you can generally pass this in using
+        ExportToWkt() on a Spatial Reference System instance.
         epsg: the proj.4 epsg file (defaults to '/usr/local/share/proj/epsg_extra').
         forceProj4: whether to perform brute force proj4 epsg file check (last resort).
         Returns: EPSG code.

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -521,7 +521,6 @@ def convert_wkt_to_epsg(wkt, epsg_directory=settings.PROJECTION_DIRECTORY, force
         forceProj4: whether to perform brute force proj4 epsg file check (last resort).
         Returns: EPSG code.
     """
-    print settings.PROJECTION_DIRECTORY
     epsg_code = None
     srs_in = osr.SpatialReference()
 

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -511,7 +511,7 @@ def import_all_layers(uploaded_data, owner=None):
     return len(import_results)
 
 
-def convert_wkt_to_epsg(wkt, epsg_directory='/usr/share/proj/', forceProj4=False):
+def convert_wkt_to_epsg(wkt, epsg_directory=settings.PROJECTION_DIRECTORY, forceProj4=False):
     """ Transform a WKT string to an EPSG code
         Arguments
         ---------

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -521,6 +521,7 @@ def convert_wkt_to_epsg(wkt, epsg_directory=settings.PROJECTION_DIRECTORY, force
         forceProj4: whether to perform brute force proj4 epsg file check (last resort).
         Returns: EPSG code.
     """
+    print settings.PROJECTION_DIRECTORY
     epsg_code = None
     srs_in = osr.SpatialReference()
 

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -20,6 +20,7 @@
 
 # Django settings for the GeoNode project.
 import os
+import pyproj
 from geonode.settings import *
 #
 # General Django development settings
@@ -115,3 +116,5 @@ MAPPROXY_CONFIG_FILENAME = 'geonode.yaml'
 # URLs will look like this: /geonode/tms/1.0.0/<layer_name>/<grid_name>/0/0/0.png and a <grid_name> will be
 #    set as '<layer_name>_<projection_id>' (by conf_from_geopackage()).
 MAPPROXY_SERVER_LOCATION = 'http://localhost:8088/geonode/tms/1.0.0/{layer_name}/{grid_name}/'
+
+PROJECTION_DIRECTORY = os.path.join(os.path.dirname(pyproj.__file__), 'data/')

--- a/scripts/epsg_extra
+++ b/scripts/epsg_extra
@@ -1,0 +1,6 @@
+# NAD 83 / Texas South Central (ftUS)
+<2278> +proj=lcc +lat_1=28.38333333333333 +lat_2=30.28333333333333 +lat_0=27.83333333333333 +lon_0=-99 +x_0=600000 +y_0=3999999.999999999 +datum=NAD83 +units=us-ft +no_defs <>
+# NAD83(NSRS2007) / Illinois East
+<3528> +proj=tmerc +lat_0=36.66666666666666 +lon_0=-88.33333333333333 +k=0.9999749999999999 +x_0=300000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs <>
+# NAD83 / Connecticut (ftUS)
+<2234> +proj=lcc +lat_1=41.2 +lat_2=41.86666666666667 +lat_0=40.83333333333334 +lon_0=-72.75 +x_0=304800.6096 +y_0=152400.3048 +datum=NAD83 +units=us-ft +no_defs <>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,7 @@ sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libsp
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
-if ["$TRAVIS" = "true"];
+if [ "$TRAVIS" = "true" ];
 then
    echo $TRAVIS
    echo "Travis hit the true clause"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,9 +25,8 @@ sudo ldconfig
 sudo touch /etc/profile.d/gdal
 sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/profile.d/gdal.sh"
 
-if ["$TRAVIS" = true];
+if ["$TRAVIS" == true];
 then
-   echo "Travis is true"
    sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.3
    # Add additional EPSG Codes
    sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,11 +28,14 @@ sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/prof
 if ["$TRAVIS" = true];
 then
    sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.3
+   # Add additional EPSG Codes
+    sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
    sudo apt-get update
    sudo apt-get -y install postgresql-9.3-postgis-2.3
+   sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 fi
 
 sudo apt-get install -y python-dev python-lxml libxslt1-dev  libpq-dev
@@ -43,9 +46,6 @@ sudo apt-get install -y libproj0 libproj-dev postgresql-plpython-9.3 python-nump
 sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libspatialite-dev libcurl4-gnutls-dev libxerces-c-dev
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
-
-# Add additional EPSG Codes
-sudo cp scripts/epsg_extra /usr/share/proj
 
 if [ -n "$1" ]
  then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,18 @@ sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libsp
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
+if [ -n "$1" ]
+ then
+ cd $1
+fi
+
+# Python packages, requirements & additional development requirements
+pip install -r requirements.txt
+pip install -r requirements.dev.txt
+
+sudo mkdir -p -m 777 importer-test-files
+aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
+
 if [ "$TRAVIS" = "true" ];
 then
    echo $TRAVIS
@@ -64,15 +76,3 @@ else
    echo "Travis hit the false clause"
    sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 fi
-
-if [ -n "$1" ]
- then
- cd $1
-fi
-
-# Python packages, requirements & additional development requirements
-pip install -r requirements.txt
-pip install -r requirements.dev.txt
-
-sudo mkdir -p -m 777 importer-test-files
-aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,6 @@ sudo su -c "echo '/usr/local/lib/gdal/lib/' >> /etc/ld.so.conf"
 sudo ldconfig
 sudo touch /etc/profile.d/gdal
 sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/profile.d/gdal.sh"
-sudo cp scripts/epsg_extra /usr/share/proj/
 
 if ["$TRAVIS" = true];
 then
@@ -45,6 +44,8 @@ sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libsp
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
+# Add additional EPSG Codes
+sudo cp scripts/epsg_extra /usr/share/proj/
 
 if [ -n "$1" ]
  then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,23 +56,10 @@ pip install -r requirements.dev.txt
 sudo mkdir -p -m 777 importer-test-files
 aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files
 
+# Add additional EPSG Codes
 if [ "$TRAVIS" = "true" ];
 then
-   echo $TRAVIS
-   echo "Travis hit the true clause"
-   # Add additional EPSG Codes
-   find . -name epsg
-   find . -name esri.extra
-   echo $HOME
-   echo "ls -la the virtualenv directory"
-   ls -la $HOME/virtualenv/
-   echo "ls -la the python2.7_with_system_site_packages directory"
-   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/
-   echo "ls -la the site packages directory"
-   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/
    sudo cp scripts/epsg_extra $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
-   echo $TRAVIS
-   echo "Travis hit the false clause"
    sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
 # Add additional EPSG Codes
-sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
+sudo cp scripts/epsg_extra /usr/share/proj
 
 if [ -n "$1" ]
  then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ sudo su -c "echo '/usr/local/lib/gdal/lib/' >> /etc/ld.so.conf"
 sudo ldconfig
 sudo touch /etc/profile.d/gdal
 sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/profile.d/gdal.sh"
-sudo cp epsg_extra /usr/share/proj/
+sudo cp scripts/epsg_extra /usr/share/proj/
 
 if ["$TRAVIS" = true];
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,7 @@ sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libsp
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
-if ["$TRAVIS" = true];
+if ["$TRAVIS" = "true"];
 then
    echo $TRAVIS
    echo "Travis hit the true clause"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,17 +25,14 @@ sudo ldconfig
 sudo touch /etc/profile.d/gdal
 sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/profile.d/gdal.sh"
 
-if ["$TRAVIS" == true];
+if ["$TRAVIS" = true];
 then
    sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.3
-   # Add additional EPSG Codes
-   sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
    sudo apt-get update
    sudo apt-get -y install postgresql-9.3-postgis-2.3
-   sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 fi
 
 sudo apt-get install -y python-dev python-lxml libxslt1-dev  libpq-dev
@@ -46,6 +43,16 @@ sudo apt-get install -y libproj0 libproj-dev postgresql-plpython-9.3 python-nump
 sudo apt-get install -y sqlite3 libsqlite3-0 libsqlite3-dev libspatialite5 libspatialite-dev libcurl4-gnutls-dev libxerces-c-dev
 sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-dev libpng12-dev libgif-dev liblzma-dev
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
+
+if ["$TRAVIS" = true];
+then
+   echo "Travis is true"
+   # Add additional EPSG Codes
+   sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
+else
+   echo "Travis is false"
+   sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
+fi
 
 if [ -n "$1" ]
  then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,6 +51,7 @@ then
    # Add additional EPSG Codes
    find . -name epsg
    find . -name esri.extra
+   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/
    sudo cp scripts/epsg_extra $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    echo $TRAVIS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,7 @@ sudo su -c "echo '/usr/local/lib/gdal/lib/' >> /etc/ld.so.conf"
 sudo ldconfig
 sudo touch /etc/profile.d/gdal
 sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/profile.d/gdal.sh"
+sudo cp epsg_extra /usr/share/proj/
 
 if ["$TRAVIS" = true];
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ sudo apt-get install -y gpsbabel libfreexl-dev unixodbc-dev libwebp-dev libjpeg-
 sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
 # Add additional EPSG Codes
-sudo cp scripts/epsg_extra /usr/share/proj/
+sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 
 if [ -n "$1" ]
  then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,7 +49,9 @@ then
    echo $TRAVIS
    echo "Travis hit the true clause"
    # Add additional EPSG Codes
-   sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
+   find . -name epsg
+   find . -name esri.extra
+   sudo cp scripts/epsg_extra $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    echo $TRAVIS
    echo "Travis hit the false clause"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,13 @@ then
    # Add additional EPSG Codes
    find . -name epsg
    find . -name esri.extra
-   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/
+   echo $HOME
+   echo "ls -la the virtualenv directory"
+   ls -la $HOME/virtualenv/
+   echo "ls -la the python2.7_with_system_site_packages directory"
+   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/
+   echo "ls -la the site packages directory"
+   ls -la $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/
    sudo cp scripts/epsg_extra $HOME/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    echo $TRAVIS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,11 +46,13 @@ sudo apt-get install -y libcrypto++-dev netcdf-bin libnetcdf-dev libexpat-dev
 
 if ["$TRAVIS" = true];
 then
-   echo "Travis is true"
+   echo $TRAVIS
+   echo "Travis hit the true clause"
    # Add additional EPSG Codes
    sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
-   echo "Travis is false"
+   echo $TRAVIS
+   echo "Travis hit the false clause"
    sudo cp scripts/epsg_extra /usr/local/lib/python2.7/dist-packages/pyproj/data/
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,9 +27,10 @@ sudo su -c "echo 'export GDAL_DATA=/usr/local/lib/gdal/share/gdal/' >> /etc/prof
 
 if ["$TRAVIS" = true];
 then
+   echo "Travis is true"
    sudo apt-get -y --no-install-recommends --force-yes install postgresql-9.3-postgis-2.3
    # Add additional EPSG Codes
-    sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
+   sudo cp scripts/epsg_extra /home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pyproj/data/
 else
    sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
Adds a utility for converting WKT strings to EPSG codes, and utilizes it in the importer if AutoIdentifyEPSG() fails to find a valid EPSG code for the dataset.  Also adds an extra_epsg file where we can add additional EPSG codes and their matching projections if they aren’t included in the default installation.  The extra_epsg file is copied to the /usr/share/proj directory where all EPSG code files are during the install process.