### PR TITLE
Adjust from 64 char to text (layer_name and name)

### DIFF
--- a/osgeo_importer/migrations/0012_auto_20170205_1124.py
+++ b/osgeo_importer/migrations/0012_auto_20170205_1124.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0011_uploadlayer_layer_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='uploadlayer',
+            name='layer_name',
+            field=models.TextField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='uploadlayer',
+            name='name',
+            field=models.TextField(null=True),
+        ),
+    ]

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -202,7 +202,7 @@ class UploadLayer(models.Model):
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
     upload_file = models.ForeignKey(UploadFile, null=True, blank=True)
     index = models.IntegerField(default=0)
-    name = models.CharField(max_length=64, null=True)
+    name = models.TextField(null=True)
     fields = JSONField(null=True, default={})
     content_type = models.ForeignKey(ContentType, blank=True, null=True)
     object_id = models.PositiveIntegerField(blank=True, null=True)
@@ -211,7 +211,7 @@ class UploadLayer(models.Model):
     import_status = models.CharField(max_length=15, blank=True, null=True)
     task_id = models.CharField(max_length=36, blank=True, null=True)
     feature_count = models.IntegerField(null=True, blank=True)
-    layer_name = models.CharField(max_length=64, null=True)
+    layer_name = models.TextField(null=True)
     layer_type = models.CharField(max_length=10, null=True)
 
     @property


### PR DESCRIPTION
Noticed an issue with long file names, since it defaults and uses the full file path as the default entry, which in exchanges's case is a lot longer than 64 chars.