### PR TITLE
Set the UploadLayer name to the unique layername

### DIFF
--- a/osgeo_importer/tests/tests_original.py
+++ b/osgeo_importer/tests/tests_original.py
@@ -228,7 +228,7 @@ class UploaderTests(TestCase):
 
         for upload_layer in upload_layers:
             for config in configs:
-                if config['upload_file_name'] == os.path.basename(upload_layer.name):
+                if config['upload_file_name'] == os.path.basename(upload_layer.upload_file.file.name):
                     payload = config['config']
                     url = '/importer-api/data-layers/{0}/configure/'.format(upload_layer.id)
                     response = client.post(

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -460,7 +460,7 @@ class ImportHelper(object):
 
                         upload_layer = UploadLayer(
                                 upload_file=upfile,
-                                name=upfile.file.name,
+                                name=layer_name,
                                 layer_name=layer_name,
                                 layer_type=layer_desc['layer_type'],
                                 fields=layer_desc.get('fields', {}),


### PR DESCRIPTION
Set the UploadLayer name to the unique layername rather than absolute path provided by upfile.file.name, since the file.name could easilt go over 64 characters