### PR TITLE
Update PostGIS table name creation to use unique layernames provided by configure_upload().

### DIFF
--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -63,7 +63,8 @@ class UploadedLayerResource(ModelResource):
         """
         self.method_check(request, allowed=['post'])
         # pk will be parsed from the url as a string but is an integer internally
-        if pk: pk = int(pk)
+        if pk is not None:
+            pk = int(pk)
 
         bundle = Bundle(request=request)
 
@@ -81,6 +82,7 @@ class UploadedLayerResource(ModelResource):
             configuration_options = configuration_options[0]
 
         if isinstance(configuration_options, dict):
+            configuration_options.update({'upload_layer_id': int(pk)})
             self.clean_configuration_options(request, obj, configuration_options)
             obj.configuration_options = configuration_options
             obj.save()
@@ -90,7 +92,6 @@ class UploadedLayerResource(ModelResource):
 
         uploaded_file = obj.upload_file
 
-        configuration_options.update({'upload_layer_id': int(pk)})
         import_result = import_object.delay(uploaded_file.id, configuration_options=configuration_options)
 
         task_id = getattr(import_result, 'id', None)
@@ -99,8 +100,7 @@ class UploadedLayerResource(ModelResource):
 
     def prepend_urls(self):
         return [url(r"^(?P<resource_name>{0})/(?P<pk>\d+)/configure{1}$".format(self._meta.resource_name,
-                                                                                      trailing_slash()),
-                self.wrap_view('import_layer'), name="importer_configure"),
+                    trailing_slash()), self.wrap_view('import_layer'), name="importer_configure"),
                 ]
 
 

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -62,6 +62,8 @@ class UploadedLayerResource(ModelResource):
         """Imports a layer
         """
         self.method_check(request, allowed=['post'])
+        # pk will be parsed from the url as a string but is an integer internally
+        if pk: pk = int(pk)
 
         bundle = Bundle(request=request)
 
@@ -88,7 +90,7 @@ class UploadedLayerResource(ModelResource):
 
         uploaded_file = obj.upload_file
 
-        configuration_options.update({'upload_layer_id': pk})
+        configuration_options.update({'upload_layer_id': int(pk)})
         import_result = import_object.delay(uploaded_file.id, configuration_options=configuration_options)
 
         task_id = getattr(import_result, 'id', None)
@@ -96,7 +98,7 @@ class UploadedLayerResource(ModelResource):
         return self.create_response(request, {'task': task_id})
 
     def prepend_urls(self):
-        return [url(r"^(?P<resource_name>{0})/(?P<pk>\w[\w/-]*)/configure{1}$".format(self._meta.resource_name,
+        return [url(r"^(?P<resource_name>{0})/(?P<pk>\d+)/configure{1}$".format(self._meta.resource_name,
                                                                                       trailing_slash()),
                 self.wrap_view('import_layer'), name="importer_configure"),
                 ]

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -16,8 +16,6 @@ from .utils import (
     FileTypeNotAllowed,
     GdalErrorHandler,
     load_handler,
-    launder,
-    increment,
     increment_filename,
     raster_import,
     decode,
@@ -252,7 +250,6 @@ class OGRImport(Import):
             logger.critical(msg)
             raise Exception(msg)
 
-
         # --- Resolve any disparity between automatically-assigned UploadLayer.layer_name and layer_name in
         # configuration options.
         # If layer_name is present in configuration_options either update UploadLayer.layer_name to match if it's unique
@@ -308,7 +305,7 @@ class OGRImport(Import):
                             and datastore_layer.get(lf) == layer_configuration.get(lf)):
                         # This update will overwrite the layer_name passed in configuration_options, stash the
                         #    intended name so we can correct it.
-                        msg = 'Will configure layer from file {} identifed by field {} with value {}'\
+                        msg = 'Will configure layer from file {} identifed by field "{}" with value {}'\
                                   .format(self.file, lf, layer_configuration[lf])
                         logger.info(msg)
                         intended_layer_name = layer_configuration.get('layer_name')

--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 import os
 import sqlite3
 
@@ -6,8 +7,10 @@ from django.conf import settings
 import gdal
 import ogr
 
-from .utils import NoDataSourceFound, GDAL_GEOMETRY_TYPES, increment, timeparse, quote_ident, parse
+from osgeo_importer.utils import NoDataSourceFound, GDAL_GEOMETRY_TYPES, increment, timeparse, quote_ident, parse
 
+
+logger = getLogger(__name__)
 
 OSGEO_INSPECTOR = getattr(settings, 'OSGEO_INSPECTOR', 'osgeo_importer.inspectors.GDALInspector')
 
@@ -144,10 +147,14 @@ class GDALInspector(InspectorMixin):
         try:
             self.data = gdal.OpenEx(filename, open_options=open_options)
         except RuntimeError:
-            raise NoDataSourceFound
+            msg = 'gdal.OpenEx({}, {}) failed.'.format(filename, open_options)
+            logger.error(msg)
+            raise NoDataSourceFound(msg)
 
         if self.data is None:
-            raise NoDataSourceFound
+            msg = 'gdal.OpenEx({}, {}) returned None.'.format(filename, open_options)
+            logger.error(msg)
+            raise NoDataSourceFound(msg)
 
         return self.data
 

--- a/osgeo_importer/migrations/0012_uploadlayer_internal_layer_name.py
+++ b/osgeo_importer/migrations/0012_uploadlayer_internal_layer_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0011_uploadlayer_layer_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='uploadlayer',
+            name='internal_layer_name',
+            field=models.CharField(max_length=64, null=True),
+        ),
+    ]

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -34,10 +34,10 @@ try:
 except ImportError:
     from django.contrib.contenttypes.generic import GenericForeignKey
 
-from .importers import OSGEO_IMPORTER
 from .utils import NoDataSourceFound
 from .utils import sizeof_fmt, load_handler
 
+OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
 DEFAULT_LAYER_CONFIGURATION = {'configureTime': False,
                                'editable': True,
                                'convert_to_date': [],

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -202,6 +202,7 @@ class UploadLayer(models.Model):
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
     upload_file = models.ForeignKey(UploadFile, null=True, blank=True)
     index = models.IntegerField(default=0)
+    # *deprecated* name of the layer, sometimes other data
     name = models.CharField(max_length=64, null=True)
     fields = JSONField(null=True, default={})
     content_type = models.ForeignKey(ContentType, blank=True, null=True)
@@ -211,6 +212,9 @@ class UploadLayer(models.Model):
     import_status = models.CharField(max_length=15, blank=True, null=True)
     task_id = models.CharField(max_length=36, blank=True, null=True)
     feature_count = models.IntegerField(null=True, blank=True)
+    # Name of the layer as known in the file/package/endpoint it came from.
+    internal_layer_name = models.CharField(max_length=64, null=True)
+    # Geonode-wide unique name for layer.
     layer_name = models.CharField(max_length=64, null=True)
     layer_type = models.CharField(max_length=10, null=True)
 

--- a/osgeo_importer/tests/test_importers.py
+++ b/osgeo_importer/tests/test_importers.py
@@ -63,11 +63,106 @@ class OGRImportTests(ImportHelper, TestCase,):
         """ Checks that if a custom layer name is provided it replaces the UploadLayer name and is used
             as the table name for data stored in PostGIS.
         """
-        self.fail('Not yet implemented')
+        # --- Prereq's to importing layers
+        # my_states.gpkg is a straightforward 1-layer vector package.
+        test_filename = 'my_states.gpkg'
+        test_filepath = os.path.join(_TEST_FILES_DIR, test_filename)
+
+        # Make temporary file (the upload/configure process removes the file & we want to keep our test file)
+        tmppath = os.path.join('/tmp', test_filename)
+        shutil.copyfile(test_filepath, tmppath)
+
+        # upload & configure_upload expect closed file objects
+        #    This is heritage from originally being closely tied to a view passing request.Files
+        of = open(tmppath, 'rb')
+        of.close()
+        files = [of]
+        upload = self.upload(files, self.admin_user)
+        self.configure_upload(upload, files)
+
+        # should be a single UploadFile resulting from configure_upload()
+        upload_file = upload.uploadfile_set.first()
+        # should be a single UploadLayer related to upload_file
+        upload_layer = upload_file.uploadlayer_set.first()
+
+        # --- Actually do imports (just import_file(), not handlers)
+        custom_layername = 'my_custom_layer'
+        configuration_options = {'upload_layer_id': upload_layer.id, 'index': 0, 'layer_name': custom_layername}
+        oi = OGRImport(upload_file.file.name, upload_file=upload_file)
+        oi.import_file(configuration_options=configuration_options)
+
+        # --- Check that PostGIS has a table matching the name of the layer set during configure_upload()
+        expected_tablename = custom_layername
+        default_tablename = upload_layer.layer_name
+        with connections['datastore'].cursor() as cursor:
+            sql = """
+                SELECT tablename
+                FROM pg_catalog.pg_tables
+                WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';
+            """
+            cursor.execute(sql)
+            tables = [row[0] for row in cursor.fetchall()]
+            self.assertIn(expected_tablename, tables)
+            self.assertNotIn(default_tablename, tables)
 
     def test_import_file_skips_duplicate_configured_layername(self):
         """ Checks that if a custom layer name is provided, but is already used the unique layer name
             created by configure_upload() & stored in UploadLayer is used as the table name for data stored
             in PostGIS.
         """
-        self.fail('Not yet implemented')
+        # --- Prereq's to importing layers
+        # my_states.gpkg is a straightforward 1-layer vector package.
+        test_filename = 'my_states.gpkg'
+        test_filepath = os.path.join(_TEST_FILES_DIR, test_filename)
+
+        # Upload two copies so we can have a duplicate name with the second.
+        # Make temporary file (the upload/configure process removes the file & we want to keep our test file)
+        filename, ext = test_filename.split('.')
+        tmppath1 = os.path.join('/tmp', '{}-1.{}'.format(filename, ext))
+        tmppath2 = os.path.join('/tmp', '{}-2.{}'.format(filename, ext))
+
+        shutil.copyfile(test_filepath, tmppath1)
+        shutil.copyfile(test_filepath, tmppath2)
+
+        # upload & configure_upload expect closed file objects
+        #    This is heritage from originally being closely tied to a view passing request.Files
+        of1 = open(tmppath1, 'rb')
+        of1.close()
+        files = [of1]
+        upload1 = self.upload(files, self.admin_user)
+        self.configure_upload(upload1, files)
+
+        of2 = open(tmppath2, 'rb')
+        of2.close()
+        files = [of2]
+        upload2 = self.upload(files, self.admin_user)
+        self.configure_upload(upload2, files)
+
+        upload_file1 = upload1.uploadfile_set.first()
+        upload_layer1 = upload_file1.uploadlayer_set.first()
+
+        upload_file2 = upload2.uploadfile_set.first()
+        upload_layer2 = upload_file2.uploadlayer_set.first()
+
+        # --- Import file1's layer using default name
+        configuration_options = {'upload_layer_id': upload_layer1.id, 'index': 0}
+        oi = OGRImport(upload_file1.file.name, upload_file=upload_file1)
+        oi.import_file(configuration_options=configuration_options)
+
+        # --- Try importing file2's layer using the same name as file1's layer.
+        configuration_options = {
+            'upload_layer_id': upload_layer2.id, 'index': 0, 'layer_name': upload_layer1.layer_name}
+        oi = OGRImport(upload_file2.file.name, upload_file=upload_file2)
+        oi.import_file(configuration_options=configuration_options)
+
+        # --- Check that PostGIS has a table matching the default layer name for upload_layer2
+        expected_tablename = upload_layer2.layer_name
+        with connections['datastore'].cursor() as cursor:
+            sql = """
+                SELECT tablename
+                FROM pg_catalog.pg_tables
+                WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';
+            """
+            cursor.execute(sql)
+            tables = [row[0] for row in cursor.fetchall()]
+            self.assertIn(expected_tablename, tables)

--- a/osgeo_importer/tests/test_importers.py
+++ b/osgeo_importer/tests/test_importers.py
@@ -1,0 +1,73 @@
+import os
+import shutil
+
+from django.contrib.auth import get_user_model
+from django.db import connections
+from django.test import TestCase
+
+from osgeo_importer.importers import OGRImport
+from osgeo_importer.tests.test_settings import _TEST_FILES_DIR
+from osgeo_importer.utils import ImportHelper
+
+User = get_user_model()
+
+
+class OGRImportTests(ImportHelper, TestCase,):
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(username='admin', password='admin', email='')
+
+    def test_import_file_uses_uploadlayer_layername(self):
+        """ Checks that the unique layer name created by configure_upload() & stored in UploadLayer is used
+            as the table name for data stored in PostGIS.
+        """
+        # --- Prereq's to importing layers
+        # my_states.gpkg is a straightforward 1-layer vector package.
+        test_filename = 'my_states.gpkg'
+        test_filepath = os.path.join(_TEST_FILES_DIR, test_filename)
+
+        # Make temporary file (the upload/configure process removes the file & we want to keep our test file)
+        tmppath = os.path.join('/tmp', test_filename)
+        shutil.copyfile(test_filepath, tmppath)
+
+        # upload & configure_upload expect closed file objects
+        #    This is heritage from originally being closely tied to a view passing request.Files
+        of = open(tmppath, 'rb')
+        of.close()
+        files = [of]
+        upload = self.upload(files, self.admin_user)
+        self.configure_upload(upload, files)
+
+        # should be a single UploadFile resulting from configure_upload()
+        upload_file = upload.uploadfile_set.first()
+        # should be a single UploadLayer related to upload_file
+        upload_layer = upload_file.uploadlayer_set.first()
+
+        # --- Actually do imports (just import_file(), not handlers)
+        configuration_options = {'upload_layer_id': upload_layer.id, 'index': 0}
+        oi = OGRImport(upload_file.file.name, upload_file=upload_file)
+        oi.import_file(configuration_options=configuration_options)
+
+        # --- Check that PostGIS has a table matching the name of the layer set during configure_upload()
+        expected_tablename = upload_layer.layer_name
+        with connections['datastore'].cursor() as cursor:
+            sql = """
+                SELECT tablename
+                FROM pg_catalog.pg_tables
+                WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';
+            """
+            cursor.execute(sql)
+            tables = [row[0] for row in cursor.fetchall()]
+            self.assertIn(expected_tablename, tables)
+
+    def test_import_file_uses_configured_layername(self):
+        """ Checks that if a custom layer name is provided it replaces the UploadLayer name and is used
+            as the table name for data stored in PostGIS.
+        """
+        self.fail('Not yet implemented')
+
+    def test_import_file_skips_duplicate_configured_layername(self):
+        """ Checks that if a custom layer name is provided, but is already used the unique layer name
+            created by configure_upload() & stored in UploadLayer is used as the table name for data stored
+            in PostGIS.
+        """
+        self.fail('Not yet implemented')

--- a/osgeo_importer/tests/tests_original.py
+++ b/osgeo_importer/tests/tests_original.py
@@ -9,6 +9,7 @@ import logging
 import osgeo
 import gdal
 from django import db
+from django.conf import settings
 from django.test import TestCase, Client
 from django.test.utils import setup_test_environment
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -25,10 +26,13 @@ from osgeo_importer.models import (
     validate_file_extension, ValidationError, validate_inspector_can_read
 )
 from osgeo_importer.handlers.geoserver import GeoWebCacheHandler
-from osgeo_importer.importers import OSGEO_IMPORTER, OGRImport
+from osgeo_importer.importers import OGRImport
 
 from osgeo_importer.utils import load_handler, launder
 from osgeo_importer.tests.test_settings import _TEST_FILES_DIR
+
+OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
+
 
 # In normal unittest runs, this will be set in setUpModule; set here for the
 # benefit of static analysis and users importing this instead of running tests.

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -1,7 +1,10 @@
 import os
-from .utils import NoDataSourceFound, load_handler
-from .importers import OSGEO_IMPORTER, VALID_EXTENSIONS
+from django.conf import settings
+from osgeo_importer.utils import NoDataSourceFound, load_handler
+from osgeo_importer.importers import VALID_EXTENSIONS
 import logging
+
+OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
 
 logger = logging.getLogger(__name__)
 

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -6,23 +6,25 @@ from tempfile import mkdtemp
 import threading
 import zipfile
 
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse
 from django.http.response import JsonResponse, HttpResponseRedirect
+from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, TemplateView
 from django.views.generic.base import View
 
 from osgeo_importer.utils import import_all_layers
 
 from .forms import UploadFileForm
-from .importers import OSGEO_IMPORTER, VALID_EXTENSIONS
+from .importers import VALID_EXTENSIONS
 from .inspectors import OSGEO_INSPECTOR
 from .models import UploadedData, UploadFile
 from .utils import import_string, ImportHelper
-from django.utils.decorators import method_decorator
-from django.contrib.auth.decorators import login_required
 
 
+OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
 OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
 OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 


### PR DESCRIPTION
Needed some refactoring to require the id of an UploadLayer associated with a layer being imported to be included in the configs.
Existing tests updated to call configure_upload() which is where unique layer names are assigned before any import attempt.
