### PR TITLE
Only process valid extensions

### DIFF
--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -6,7 +6,8 @@ from zipfile import is_zipfile, ZipFile
 
 from django import forms
 
-from osgeo_importer.validators import valid_file, IGNORE_EXTENSIONS, IGNORE_FILES
+from osgeo_importer.importers import VALID_EXTENSIONS
+from osgeo_importer.validators import valid_file
 
 from .models import UploadFile
 from .validators import validate_inspector_can_read, validate_shapefiles_have_all_parts
@@ -41,7 +42,7 @@ class UploadFileForm(forms.Form):
                     for zipname in zip.namelist():
                         _, zipext = os.path.splitext(os.path.basename(zipname))
                         zipext = zipext.lstrip('.').lower()
-                        if zipext not in IGNORE_EXTENSIONS and zipname.lower() not in IGNORE_FILES:
+                        if zipext in VALID_EXTENSIONS:
                             process_files.append(zipname)
             else:
                 process_files.append(f.name)

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -51,8 +51,8 @@ class UploadFileForm(forms.Form):
         if not validate_shapefiles_have_all_parts(process_files):
             self.add_error('file', 'Shapefiles must include .shp,.dbf,.shx,.prj')
 
-        # Unpack all zip files and create list of cleaned file objects, excluding any with extensions in
-        #    IGNORE_EXTENSIONS
+        # Unpack all zip files and create list of cleaned file objects, excluding any not in
+        #    VALID_EXTENSIONS
         cleaned_files = []
         for f in files:
             if f.name in process_files:

--- a/osgeo_importer/tests/test_validators.py
+++ b/osgeo_importer/tests/test_validators.py
@@ -29,6 +29,6 @@ class ValidatorTests(TestCase):
         with open(invalid_filepath, 'rb') as invalid_file:
             # The invalid file should return an error
             expected_errors = [
-                'example.pdf: "pdf" not found in VALID_EXTENSIONS, NONDATA_EXTENSIONS, IGNORE_EXTENSIONS'
+                'example.pdf: "pdf" not found in VALID_EXTENSIONS, NONDATA_EXTENSIONS'
             ]
             self.assertEqual(valid_file(invalid_file), expected_errors)

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -19,7 +19,7 @@ ALL_OK_EXTENSIONS = set(VALID_EXTENSIONS) | set(NONDATA_EXTENSIONS)
 
 def valid_file(file):
     """ Returns an empty list if file is valid, or a list of strings describing problems with the file.
-        @see VALID_EXTENSIONS, NONDATA_EXTENSIONS, IGNORE_EXTENSIONS
+        @see VALID_EXTENSIONS, NONDATA_EXTENSIONS
     """
     errors = []
     basename = os.path.basename(file.name)

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -13,16 +13,8 @@ OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.O
 logger = logging.getLogger(__name__)
 
 NONDATA_EXTENSIONS = ['shx', 'prj', 'dbf', 'xml', 'sld']
-IGNORE_EXTENSIONS = ['txt', 'qgs']
 
-# These are files to skip processing if they're found inside of a zip
-# Make sure these are all lowercase & note they will match any case,
-#    i.e. 'hi' will ignore 'hi', 'Hi', 'hI', 'HI'
-IGNORE_FILES = [
-    '__macosx', 'ds_store',  # added to OSX-generated zip files
-]
-
-ALL_OK_EXTENSIONS = set(VALID_EXTENSIONS) | set(NONDATA_EXTENSIONS) | set(IGNORE_EXTENSIONS)
+ALL_OK_EXTENSIONS = set(VALID_EXTENSIONS) | set(NONDATA_EXTENSIONS)
 
 
 def valid_file(file):
@@ -43,7 +35,7 @@ def valid_file(file):
                     errors.extend(content_errors)
     elif extension not in ALL_OK_EXTENSIONS:
         errors.append(
-            '{}: "{}" not found in VALID_EXTENSIONS, NONDATA_EXTENSIONS, IGNORE_EXTENSIONS'.format(basename, extension)
+            '{}: "{}" not found in VALID_EXTENSIONS, NONDATA_EXTENSIONS'.format(basename, extension)
         )
 
     return errors


### PR DESCRIPTION
This PR is a proposal that we only process valid extensions in our list, rather than trying to figure out all of the different types of files that users may have in their zip files and exclude those.  I expect that users will be fairly unpredictable in what they'll include in their zip files outside of the required file types for a layer, and that this will be easier than figuring out all of those file types they may include.