### PR TITLE
Add importer-client as pypi package

### DIFF
--- a/osgeo_importer/templates/osgeo_importer/bulk_import.html
+++ b/osgeo_importer/templates/osgeo_importer/bulk_import.html
@@ -18,6 +18,10 @@
 </div>
 <div id="main"></div>
 
-<script type="text/javascript" src="/static/osgeo_importer/js/importer-client_0.0.1.js"></script>
+<script type="text/javascript" src="/static/osgeo_importer_client/js/osgeo_importer_client.min.js"></script>
+<script type="text/javascript">
+	var importer = new Importer('main', { server: '{{SITEURL}}'});
+	importer.view();
+</script>
 
 {% endblock %}

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -77,7 +77,7 @@ LOCALE_PATHS = (
     ) + LOCALE_PATHS
 
 
-INSTALLED_APPS = INSTALLED_APPS + ("osgeo_importer",)
+INSTALLED_APPS = INSTALLED_APPS + ("osgeo_importer","osgeo_importer_client",)
 # # Remove 'geonode.geoserver', useful for experimenting with a geoserver-less configuration.
 # INSTALLED_APPS = [ a for a in INSTALLED_APPS if a != 'geonode.geoserver' ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ coverage==4.3.4
 git+https://github.com/mapproxy/mapproxy.git@07552da8
 
 # You will also need gdal/ogr.  See Developer Notes section of docs.
+django-osgeo-importer-client==0.0.4


### PR DESCRIPTION
## What does this PR do?

It adds the importer client as a django app. 
use SITEURL for the server settings
Importer Client has version 0.0.4 with a few improvements. The progress can be found here: 
https://github.com/terranodo/importer-client