### PR TITLE
Postgres Schema

### DIFF
--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -73,9 +73,18 @@ class FieldConverterHandler(GetModifiedFieldsMixin, ImportHandlerMixin):
 
     def convert_field_to_time(self, layer, field):
         d = db.connections[settings.OSGEO_DATASTORE].settings_dict
-        connection_string = "PG:dbname='%s' user='%s' password='%s' host='%s' port='%s'" % (d['NAME'], d['USER'],
+
+        schema = 'public'
+
+        if 'OPTIONS' in d and 'options' in d['OPTIONS']:
+            search_path = d['OPTIONS']['options'].split('=')[-1]
+            schema = map(str.strip, search_path.split(','))[0]
+
+        connection_string = "PG:dbname='%s' user='%s' password='%s' host='%s' port='%s' schemas=%s" % (
+                                                                                            d['NAME'], d['USER'],
                                                                                             d['PASSWORD'], d['HOST'],
-                                                                                            d['PORT'])
+                                                                                            d['PORT'],
+                                                                                            schema)
 
         with self.field_converter(connection_string) as datasource:
             return datasource.convert_field(layer, field)

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -97,7 +97,6 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
         return {
               'database': db_settings['NAME'],
               'passwd': db_settings['PASSWORD'],
-              'namespace': self.workspace_namespace_uri,
               'type': 'PostGIS',
               'dbtype': 'postgis',
               'host': db_settings['HOST'],

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -171,9 +171,18 @@ class OGRImport(Import):
 
         if target_store is None:
             d = db.connections[settings.OSGEO_DATASTORE].settings_dict
-            connection_string = "PG:dbname='%s' user='%s' password='%s' host='%s' port='%s'" % (d['NAME'], d['USER'],
+
+            schema = 'public'
+
+            if 'OPTIONS' in d and 'options' in d['OPTIONS']:
+                search_path = d['OPTIONS']['options'].split('=')[-1]
+                schema = map(str.strip, search_path.split(','))[0]
+
+            connection_string = "PG:dbname='%s' user='%s' password='%s' host='%s' port='%s' schemas=%s" % (
+                                                                                                d['NAME'], d['USER'],
                                                                                                 d['PASSWORD'],
-                                                                                                d['HOST'], d['PORT'])
+                                                                                                d['HOST'], d['PORT'],
+                                                                                                schema)
             self.target_store = connection_string
 
     def open_target_datastore(self, connection_string, *args, **kwargs):


### PR DESCRIPTION
This fixes two isues:

- Currently all the data is ingested into the public schema, This makes it possible to store the data in a different schema
- The Geoservers may be created in an existing workspace that has a different nampsapce that the expected namespace, which will end up breaking the store, or more precisely layers add from the store will not work. This removes the namespace from the store (will be inherited on creation)  