### PR TITLE
Update GeoNode Requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,6 @@ importer-test-files/
 profile.sh
 gs/
 gdal-2.1.0-linux-bin.tar.gz
+osgeo_importer_prj/uploaded/
 
 osgeo_importer_prj/development.db

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -49,6 +49,8 @@ LOCAL_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+MEDIA_ROOT = LOCAL_ROOT + "/uploaded"
+
 WSGI_APPLICATION = "osgeo_importer_prj.wsgi.application"
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,7 @@
 Django==1.8.15
 psycopg2==2.7.1
 
-# Install GeoNode tagged at version 2.5.15
--e git+https://github.com/GeoNode/geonode.git@2.5.15#egg=GeoNode
+GeoNode<=2.6c1, >=2.5.12
 
 awscli==1.11.63
 numpy==1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ sphinx-autobuild==0.6.0
 
 Django==1.8.15
 
-# Install GeoNode tagged at version 2.5.15
--e git+https://github.com/GeoNode/geonode.git@2.5.15#egg=GeoNode
+GeoNode<=2.6c1, >=2.5.12
 
 awscli==1.11.63
 flake8==3.3.0


### PR DESCRIPTION
Update the Geonode requirements to use PyPi and give a range of versions allowed that I’ve tested and verified as passing the tests.  Also moved the uploaded directory to within the project structure instead of inside of Geonode due to permissions issues with the old upload directory when installing Geonode via PyPi.