### PR TITLE
Update GeoNode version required

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,7 +12,7 @@ sphinx-autobuild==0.6.0
 
 Django==1.8.15
 
-GeoNode>=2.5.12
+GeoNode>=2.6.1
 
 django-tastypie>=0.12.2,<0.14
 


### PR DESCRIPTION
This should hopefully fix the Travis CI build failing.

Edit: Looks like it doesn't and there's a new error now with osgeo.