### PR TITLE
Esri projection support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   django:
     build: .
+    environment:
+    - PYTHONUNBUFFERED=0
     depends_on:
       - postgres
     command: python manage.py runserver 0.0.0.0:8000

--- a/osgeo_importer/tests/tests_original.py
+++ b/osgeo_importer/tests/tests_original.py
@@ -1266,7 +1266,7 @@ class UploaderTests(ImportHelper, TestCase):
         result = self.generic_import(filename, configs=configs)
 
         feature_type = self.catalog.get_resource(result.name)
-        self.assertEqual(feature_type.projection, 'EPSG:2278')
+        self.assertEqual(feature_type.projection, 'EPSG:4326')
 
     def test_gwc_handler(self):
         """Tests the GeoWebCache handler

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -623,6 +623,89 @@ def convert_wkt_to_epsg(wkt, epsg_directory=settings.PROJECTION_DIRECTORY, force
         raise Exception(msg)
 
 
+def reproject_coordinate_system(original_layer_name, layer_name, in_shp_layer, layer_path):
+
+    shp_driver = ogr.GetDriverByName('ESRI Shapefile')
+
+    # input SpatialReference
+    input_srs = in_shp_layer.GetSpatialRef()
+
+    # output SpatialReference
+    output_srs = osr.SpatialReference()
+    output_srs.ImportFromEPSG(4326)
+
+    # create the CoordinateTransformation
+    coord_trans = osr.CoordinateTransformation(input_srs, output_srs)
+
+    # create the output layer
+    output_shp_file = '{}/{}_reproj.shp'.format(layer_path, layer_name)
+
+    # check if output file exists if yes delete it
+    if os.path.exists(output_shp_file):
+        shp_driver.DeleteDataSource(output_shp_file)
+
+    # create a new Shapefile object
+    output_shp_dataset = shp_driver.CreateDataSource(output_shp_file)
+
+    # create a new layer in output Shapefile and define its geometry type
+    output_shp_layer = output_shp_dataset.CreateLayer('{}_4326'.format(layer_name), geom_type=ogr.wkbMultiPolygon)
+
+    # add fields to the new output Shapefile
+    # get list of attribute fields
+    # create new fields for output
+    in_layer_def = in_shp_layer.GetLayerDefn()
+    for i in range(0, in_layer_def.GetFieldCount()):
+        field_def = in_layer_def.GetFieldDefn(i)
+        output_shp_layer.CreateField(field_def)
+
+    # get the output layer's feature definition
+    output_layer_def = output_shp_layer.GetLayerDefn()
+
+    # loop through the input features
+    in_feature = in_shp_layer.GetNextFeature()
+    while in_feature:
+        # get the input geometry
+        geom = in_feature.GetGeometryRef()
+        # reproject the geometry
+        geom.Transform(coord_trans)
+        # create a new feature
+        output_feature = ogr.Feature(output_layer_def)
+        # set the geometry and attribute
+        output_feature.SetGeometry(geom)
+        for i in range(0, output_layer_def.GetFieldCount()):
+            output_feature.SetField(output_layer_def.GetFieldDefn(i).GetNameRef(), in_feature.GetField(i))
+        # add the feature to the shapefile
+        output_shp_layer.CreateFeature(output_feature)
+        # destroy the features and get the next input feature
+        output_feature.Destroy()
+        in_feature.Destroy()
+        in_feature = in_shp_layer.GetNextFeature()
+
+    # close the shapefiles
+    output_shp_dataset.Destroy()
+
+    spatialRef = osr.SpatialReference()
+    spatialRef.ImportFromEPSG(4326)
+
+    spatialRef.MorphToESRI()
+    prj_file = open('{}/{}_reproj.prj'.format(layer_path, layer_name), 'w')
+    prj_file.write(spatialRef.ExportToWkt())
+    prj_file.close()
+
+    for file_name in os.listdir(layer_path):
+        if os.path.splitext(file_name)[0] == original_layer_name:
+            os.remove(os.path.join(layer_path, file_name))
+            print 'Removed {}'.format(file_name)
+
+    for file_name in os.listdir(layer_path):
+        if os.path.splitext(file_name)[0] == '{}_reproj'.format(layer_name):
+            extension = os.path.splitext(file_name)[1][1:].strip().lower()
+            os.rename(os.path.join(layer_path, file_name), os.path.join(layer_path, '{}.{}'.format(original_layer_name, extension)))
+            print 'Renaming {} to {}'.format(file_name, original_layer_name)
+
+    return '{0}:{1}'.format(output_srs.GetAuthorityName(None), output_srs.GetAuthorityCode(None))
+
+
 def database_schema_name():
     db_settings = db.connections[settings.OSGEO_DATASTORE].settings_dict
     schema = 'public'


### PR DESCRIPTION
This PR adds support for ESRI projections that previously failed in Importer.  If we can't automatically find an EPSG code for the layer, we reproject it into 4326 by creating a new layer and projecting all of the features to that new projection, and then we import this new layer instead.  