### PR TITLE
Removes the workspace from the typename, which removes it from the URL.

### DIFF
--- a/osgeo_importer/handlers/geonode/publish_handler.py
+++ b/osgeo_importer/handlers/geonode/publish_handler.py
@@ -92,8 +92,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
             logger.critical(msg)
             raise Exception(msg)
 
-        workspace_name = self.workspace
-        typename = '{}:{}'.format(workspace_name.encode('utf-8'), layer_name.encode('utf-8'))
+        typename = '{}'.format(layer_name.encode('utf-8'))
 
         new_layer_kwargs = {
             'name': layer_name,


### PR DESCRIPTION
Currently the workspace is in every single URL followed by a colon and then the rest of the layers name.  This just clutters up the URL and from what I can tell is unnecessary.  If anyone knows the reason it needs to be there, feel free to let me know.  But all of the tests are passing locally with this change.