### PR TITLE
Bump Geonode to 2.6.3

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,7 +12,7 @@ sphinx-autobuild==0.6.0
 
 Django==1.8.15
 
-GeoNode>=2.5.12
+GeoNode==2.6.3
 
 django-tastypie>=0.12.2,<0.14
 


### PR DESCRIPTION
Bumps geonode to version 2.6.3 to avoid issues with future versions of shapely.