### PR TITLE
Raster/Vector Fixes

### DIFF
--- a/osgeo_importer/__init__.py
+++ b/osgeo_importer/__init__.py
@@ -4,4 +4,4 @@ __version__ = (0, 2, 2)
 
 os.environ.setdefault('PGCLIENTENCODING', 'UTF-8')
 os.environ.setdefault('SHAPE_ENCODING', 'UTF-8')
-os.environ.setdefault('PG_USE_COPY', 'no')
+os.environ.setdefault('PG_USE_COPY', 'yes')

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -308,7 +308,7 @@ class GeoserverPublishCoverageHandler(GeoserverHandlerMixin):
         ensure_workspace_exists(self.catalog, self.workspace_name, self.workspace_namespace_uri)
         workspace = self.catalog.get_workspace(self.workspace_name)
 
-        return self.catalog.create_coveragestore(name, layer, workspace, False)
+        return self.catalog._create_coveragestore(name, "file:{}".format(layer), workspace, False, True)
 
 
 class GeoWebCacheHandler(GeoserverHandlerMixin):

--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -231,7 +231,7 @@ class GDALInspector(InspectorMixin):
         # Get main layer first.
         elif opened_file.RasterCount > 0:
             layer_description = {'index': len(description),
-                                 'layer_name': self.file,
+                                 'layer_name': os.path.splitext(os.path.basename(self.file))[0],
                                  'path': self.file,
                                  'raster': True,
                                  'layer_type': 'raster',


### PR DESCRIPTION
- Fix missing first feature on vector reprojection
- Change ```PG_USE_COPY``` to make it possible to ingest larger datasets
- Change the geometery auto promotion to only be invoked if there are two types/classes of geometries in a shapefile 
- Make sure raster layers get their name based on the importer layer name. 
- Use external raster when creating a geoserver coverage store, instead of uploading the raster on store creation