### PR TITLE
GeoServer stores weren’t being created automatically

### DIFF
--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -145,6 +145,8 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
 
         try:
             s = self.catalog.get_store(use_conn_str['name'])
+            if s is None:
+                raise FailedRequestError
         except FailedRequestError:
             # Couldn't get the store, try creating it.
             if connection_string is not None:


### PR DESCRIPTION
gsconfig now returns `None` rather than raising an error, so the geoserver handler needs to throw an error if response is `None` to capture this responsibility

Edit: kind of a duplicate of #180 not sure why it was closed?