### PR TITLE
Updates to SLD Handling and Exception Propagation

### DIFF
--- a/osgeo_importer/admin.py
+++ b/osgeo_importer/admin.py
@@ -1,4 +1,4 @@
-from .models import UploadedData, UploadLayer, UploadFile
+from .models import UploadedData, UploadLayer, UploadFile, UploadException
 from django.contrib import admin
 
 
@@ -15,6 +15,10 @@ class UploadedDataAdmin(admin.ModelAdmin):
     list_filter = ('user', 'state', 'complete')
 
 
+class UploadExceptionAdmin(admin.ModelAdmin):
+    model = UploadException
+
+admin.site.register(UploadException, UploadExceptionAdmin)
 admin.site.register(UploadLayer, UploadedLayerAdmin)
 admin.site.register(UploadedData, UploadedDataAdmin)
 admin.site.register(UploadFile, UploadAdmin)

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -458,11 +458,12 @@ class GenericSLDHandler(GeoserverHandlerMixin):
         """
         self.catalog._cache.clear()
         self.layer = self.catalog.get_layer(layer)
-        try:
-            is_default_type = self.layer.default_style.name in ['generic', 'polygon', 'point', 'line', 'raster']
-        except:
+
+        if self.layer and self.layer.default_style:
+            return self.layer.default_style.name in ['generic', 'polygon', 'point', 'line', 'raster']
+        else:
             return False
-        return self.layer and self.layer.default_style and is_default_type
+
 
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -9,6 +9,8 @@ from osgeo_importer.importers import UPLOAD_DIR
 from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
 from geonode.upload.utils import make_geogig_rest_payload, init_geogig_repo
+from geonode.geoserver.helpers import get_sld_for, _style_contexts, _style_templates
+from geoserver.catalog import ConflictingDataError
 from geoserver.support import DimensionInfo
 from osgeo_importer.utils import increment_filename, database_schema_name
 import re
@@ -439,25 +441,61 @@ class GeoServerBoundsHandler(GeoserverHandlerMixin):
 
 class GenericSLDHandler(GeoserverHandlerMixin):
     """
-    Handles cases in Geoserver 2.8x+ where the generic sld is used.  The generic style causes service exceptions.
+    Creates a unique style if one of the Geoserver defaults is applied.
     """
 
     def can_run(self, layer, layer_config, *args, **kwargs):
         """
-        Only run this handler if the layer is found in Geoserver and the layer's style is the generic style.
+        Only run this handler if the layer is found in Geoserver and the layer's style is one of the default styles.
         """
         self.catalog._cache.clear()
         self.layer = self.catalog.get_layer(layer)
+        is_default_type = self.layer.default_style.name in ['generic', 'polygon', 'point', 'line', 'raster']
 
-        return self.layer and self.layer.default_style and self.layer.default_style.name == 'generic'
+        return self.layer and self.layer.default_style and is_default_type
 
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):
         """
-        Replace the generic layer with the 'point' layer.
+        Replace the default layer style with one of the boilerplate styles.
         """
-        self.layer.default_style = 'point'
-        self.catalog.save(self.layer)
+        name = self.layer.name
+
+        sld = get_sld_for(self.catalog, self.layer)
+
+        style = None
+
+        if sld is not None:
+            try:
+                self.catalog.create_style(name, sld, raw=True)
+            except ConflictingDataError as e:
+                msg = 'There was already a style named %s in GeoServer, try using another name: "%s"' % (name, str(e))
+                logger.error(msg)
+                try:
+                    self.catalog.create_style(name + '_layer', sld, raw=True)
+                except ConflictingDataError as e:
+                    msg = 'There was already a style named %s in GeoServer, cannot overwrite: "%s"' % (name, str(e))
+                    logger.error(msg)
+                    e.args = (msg,)
+
+            if style is None:
+                try:
+                    style = self.catalog.get_style(name)
+                except BaseException:
+                    logger.warn('Could not retreive the Layer default Style name')
+                    # what are we doing with this var?
+                    msg = 'No style could be created for the layer, falling back to POINT default one'
+                    try:
+                        style = self.catalog.get_style(name + '_layer')
+                    except BaseException:
+                        style = self.catalog.get_style('point')
+                        logger.warn(msg)
+                        e.args = (msg,)
+
+            if style:
+                self.layer.default_style = style
+                self.catalog.save(self.layer)
+
 
 
 class GeoServerStyleHandler(GeoserverHandlerMixin):

--- a/osgeo_importer/static/osgeo_importer/css/importer.css
+++ b/osgeo_importer/static/osgeo_importer/css/importer.css
@@ -150,3 +150,7 @@
     box-shadow: inset 1px 1px 6px 0px rgba(0, 0, 0, 0.5);
     font-weight: bold;
 }
+
+.steps-indicator li a {
+    text-transform: none;
+}

--- a/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
+++ b/osgeo_importer/static/osgeo_importer/partials/uploadWizard.html
@@ -58,6 +58,14 @@
                     <input id="layerName" type="text" class=input-lg ng-model="layer.configuration_options.name">
                 </div>
 
+                <div class="form-group" ng-if="layer.configuration_options.styles">
+                    <label for="default_style">Default Style</label>
+                    <select class="form-control ng-pristine ng-valid" id="default_style" name="default_style" ng-model="layer.configuration_options.default_style">
+                        <option value="" selected="selected">---------</option>
+                        <option ng-repeat="style in layer.configuration_options.styles" value="{{style}}">{{style}}</option>
+                    </select>
+                </div>
+
                 <div class="import-wizard-button">
                     <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
                 </div>

--- a/osgeo_importer/tasks.py
+++ b/osgeo_importer/tasks.py
@@ -5,7 +5,7 @@ import celery
 from osgeo_importer.views import OSGEO_IMPORTER
 import logging
 from geonode.celery_app import app
-from osgeo_importer.models import UploadLayer
+from osgeo_importer.models import UploadLayer, UploadException
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,9 @@ class RecordImportStateTask(ExceptionLoggingTask):
         ulid = configuration_options['upload_layer_id']
         try:
             ul = UploadLayer.objects.get(id=ulid)
+            UploadException.objects.create(error=exc,
+                                   verbose_traceback=einfo,
+                                   task_id=task_id, upload_layer=ul)
         except UploadLayer.DoesNotExist:
             msg = 'Got invalid UploadLayer id: {}'.format(ulid)
             logger.error(msg)

--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -482,6 +482,7 @@ class ImportHelper(object):
 
         # Loop through and create uploadfiles and uploadlayers
         upfiles = []
+        styles = [os.path.basename(x) for x in finalfiles if '.sld' in x.lower()]
         for each in finalfiles:
             upfile = UploadFile.objects.create(upload=upload)
             upfiles.append(upfile)
@@ -502,6 +503,8 @@ class ImportHelper(object):
                 for layer_desc in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
                     configuration_options.update({'index': layer_desc.get('index')})
+                    if styles:
+                        configuration_options.update({'styles': styles})
                     # layer_basename is the string to start the layer name with
                     # The inspector will use a full path to the file for .tif layer names.
                     # We'll use just the basename of the path (no modification if it's not a path).


### PR DESCRIPTION
1. This PR ports over the process followed by the geonode.uploader with regards to sld association for newly created layers. A new sld will be created for each layer rather than assigning points.sld to each layer. The screen shot below is the result of successfully uploading/importing three different geometry types, each resulting in a sld named after the layer.

<img width="885" alt="screen shot 2017-10-19 at 4 33 30 am" src="https://user-images.githubusercontent.com/947403/31771556-2e84bed0-b4a2-11e7-9390-6d0ea867c31a.png">

2. This PR also allows .sld files to be included in the layer configuration options. If a user uploads a file which include a .sld, this change will enable the import wizard to display a selector of the available styles associated with the upload so that the user can choose which .sld to apply as the default style.

![screen shot 2017-10-20 at 7 30 30 am](https://user-images.githubusercontent.com/947403/31820858-b2c6f714-b568-11e7-937e-a6cc947a6562.png)

The following screenshot is the result of a successful import of a shapefile with several sld files included in the initial upload.

![screen shot 2017-10-20 at 7 46 17 am](https://user-images.githubusercontent.com/947403/31821501-f30fdb40-b56a-11e7-9ef9-bf4f15b8c7a9.png)

3. Lastly, this PR allows task failures to be stored in the UploadException model so that admin users can review the root cause of import failures without requiring system level access to the logs.

![screen shot 2017-10-19 at 8 46 05 am](https://user-images.githubusercontent.com/947403/31826889-ed9c6af0-b57b-11e7-9703-9445b4b27129.png)
