### PR TITLE
Don't use COPY when ingesting CSV

### DIFF
--- a/osgeo_importer/__init__.py
+++ b/osgeo_importer/__init__.py
@@ -4,4 +4,3 @@ __version__ = (0, 2, 2)
 
 os.environ.setdefault('PGCLIENTENCODING', 'UTF-8')
 os.environ.setdefault('SHAPE_ENCODING', 'UTF-8')
-os.environ.setdefault('PG_USE_COPY', 'yes')

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -312,7 +312,15 @@ class GeoserverPublishCoverageHandler(GeoserverHandlerMixin):
         ensure_workspace_exists(self.catalog, self.workspace_name, self.workspace_namespace_uri)
         workspace = self.catalog.get_workspace(self.workspace_name)
 
-        return self.catalog._create_coveragestore(name, "file:{}".format(layer), workspace, False, True)
+        """
+        Hack to allow raster upload to geoserver, or use the importer generated one via NFS/EFS instead.
+        This should be a per layer attribute instead of a global config.
+        """
+        UPLOAD_RASTER = getattr(settings, 'OSGEO_IMPORTER_UPLOAD_RASTER_TO_GEOSERVER', True)
+        if UPLOAD_RASTER:
+            return self.catalog._create_coveragestore(name, layer, workspace, False, False)
+        else:
+            return self.catalog._create_coveragestore(name, "file:{}".format(layer), workspace, False, True)
 
 
 class GeoWebCacheHandler(GeoserverHandlerMixin):

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -365,6 +365,11 @@ class OGRImport(Import):
                 # Prevent numeric field overflow for shapefiles https://trac.osgeo.org/gdal/ticket/5241
                 if target_file.GetDriver().GetName() == 'PostgreSQL':
                     target_create_options.append('PRECISION=NO')
+                    # Hack for CSV ingest into postgres. When using COPY, OGR prepends a bad newline to each feature
+                    if data.GetDriver().ShortName.lower() == 'csv':
+                        os.environ["PG_USE_COPY"] = "false"
+                    else:
+                        os.environ["PG_USE_COPY"] = "true"
 
                 layer_options['modified_fields'] = {}
                 layer = data.GetLayer(layer_options.get('index'))


### PR DESCRIPTION
This fixes CSV ingest into postgers - currently OGR appends a fake newline to each feature when ingesting CSV into postgres when using COPY.
As a workaround, this uses INSERT for CSV and COPY for all other formats.

Error returned by OGR:
```
ERROR 1: COPY statement failed.
ERROR:  extra data after last expected column
CONTEXT:  COPY testme2222, line 1: "\N  9003    2001-02-02                      30      30                      POINT (-93.676963 42.011123)"
```
