### PR TITLE
Ensure KML/KMZ is ingested with valid geometry 

### DIFF
--- a/osgeo_importer/__init__.py
+++ b/osgeo_importer/__init__.py
@@ -4,4 +4,3 @@ __version__ = (0, 2, 2)
 
 os.environ.setdefault('PGCLIENTENCODING', 'UTF-8')
 os.environ.setdefault('SHAPE_ENCODING', 'UTF-8')
-os.environ.setdefault('PG_USE_COPY', 'yes')


### PR DESCRIPTION
Currently the majority the KML/KMZ get ingested with undefined geometry, or geometry type 0.
This adds the ```KML``` and ```LIBKML``` drivers to the types modified by the ```types get_layer_type``` method.

Complex KML/KMZ (ones with say, a point/multi-point and a polygon/multi-polygon) will now correctly fail to ingest