### PR TITLE
Fix in case default_style is null

### DIFF
--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -459,10 +459,14 @@ class GenericSLDHandler(GeoserverHandlerMixin):
         self.catalog._cache.clear()
         self.layer = self.catalog.get_layer(layer)
 
-        if self.layer and self.layer.default_style:
-            return self.layer.default_style.name in ['generic', 'polygon', 'point', 'line', 'raster']
-        else:
-            return False
+        if self.layer:
+            if self.layer.default_style:
+                return self.layer.default_style.name in ['generic', 'polygon', 'point', 'line', 'raster']
+            else:
+                if not any([layer_config.get('default_style', None), layer_config.get('styles', None)]):
+                    return True
+
+        return False
 
 
     @ensure_can_run


### PR DESCRIPTION
In some cases ```default_style``` is reporting None even though a default style is actually set.
This assumes that if None is returned, and a user did not upload a style with the layer, then a layer specific default style should be applied