### PR TITLE
use actual field type name

### DIFF
--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -209,7 +209,7 @@ class GDALInspector(InspectorMixin):
                     field_desc = {}
                     field = layer_definition.GetFieldDefn(i)
                     field_desc['name'] = field.GetName()
-                    field_desc['type'] = field.GetFieldTypeName(i)
+                    field_desc['type'] = field.GetFieldTypeName(field.type)
                     layer_description['fields'].append(field_desc)
 
             description.append(layer_description)


### PR DESCRIPTION
Instead of using the type ID number associated with the field (field.type), the importer uses the position of the field in the layer ("i").  This PR fixes this.

GetFieldTypeName(int) -> returns a human-readable (i.e. "Integer" or "Real") given a type field type id.

http://www.gdal.org/classOGRFieldDefn.html

Filed Type IDs:
http://www.gdal.org/ogr__core_8h.html#a787194bea637faf12d61643124a7c9fc