### PR TITLE
Set the alternate field

### DIFF
--- a/osgeo_importer/handlers/geonode/publish_handler.py
+++ b/osgeo_importer/handlers/geonode/publish_handler.py
@@ -103,6 +103,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
             'store': store_name,
             'storeType': store_type,
             'typename': typename,
+            'alternate': typename,
             'title': layer_title,
             "abstract": layer_abstract,
             'owner': owner,


### PR DESCRIPTION
geonode 2.7 requires the alternate field to be set for use in building the details_url.