### PR TITLE
Read encoding from cpg file if exist

### DIFF
--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -502,7 +502,7 @@ class ImportHelper(object):
             _, upfile_ext = os.path.splitext(upfile_basename)
 
             # If this file isn't part of a shapefile
-            if upfile_ext.lower() not in ['.prj', '.dbf', '.shx']:
+            if upfile_ext.lower() not in ['.prj', '.dbf', '.shx', '.cpg']:
                 description = self.get_fields(each)
                 for layer_desc in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -12,7 +12,7 @@ OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.O
 
 logger = logging.getLogger(__name__)
 
-NONDATA_EXTENSIONS = ['shx', 'prj', 'dbf', 'xml', 'sld']
+NONDATA_EXTENSIONS = ['shx', 'prj', 'dbf', 'xml', 'sld', 'cpg']
 
 ALL_OK_EXTENSIONS = set(VALID_EXTENSIONS) | set(NONDATA_EXTENSIONS)
 


### PR DESCRIPTION
This will attempt to set the encoding specified in a cpg file, if one is provided, when ingesting the data.
eg, `ANSI 1252`, `UTF-8`, `cp950` should be set when data is ingested.

