### PR TITLE
call get_or_create_target_dataset

### DIFF
--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -267,7 +267,7 @@ class GeoserverPublishHandler(GeoserverHandlerMixin):
         if store_type.lower() == 'geogig':
             self.geogig_handler(store, layer, layer_config, request_user)
 
-        return self.catalog.publish_featuretype(layer, self.get_or_create_datastore(layer_config, request_user),
+        return self.catalog.publish_featuretype(layer, store,
                                                 layer_config.get('srs', self.srs))
 
     def geogig_version(self):


### PR DESCRIPTION
This PR refactors `create_target_dataset` to `get_or_create_target_dataset` to account for the cases when the target dataset exists. In the case where the import task fails after the create dataset step, the user can resubmit the import request to continue processing.