### PR TITLE
No need to process the sld file if included.

### DIFF
--- a/osgeo_importer/utils.py
+++ b/osgeo_importer/utils.py
@@ -502,7 +502,8 @@ class ImportHelper(object):
             _, upfile_ext = os.path.splitext(upfile_basename)
 
             # If this file isn't part of a shapefile
-            if upfile_ext.lower() not in ['.prj', '.dbf', '.shx', '.cpg']:
+            if upfile_ext.lower() not in ['.prj', '.dbf', '.shx',
+                                          '.cpg', '.sld']:
                 description = self.get_fields(each)
                 for layer_desc in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()


### PR DESCRIPTION
This PR avoids the fatal error seen below for some .sld files that are included in the upload. The files still upload but importer raises an exception which causes the user to think the process was aborted. Since the files upload, the user is able to exit the error dialog and proceed with creating/importing the layer along with the sld.

Given that this method attempts to describe the layer info and create an UploadLayer instance, it doesn't apply to .sld files so its safe to exclude .sld files from processing.

>>> data = gdal.OpenEx('/scratch/media_root/osgeo_importer_uploads/14/Public_Schools.sld', open_options=[])
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
RuntimeError: `/scratch/media_root/osgeo_importer_uploads/14/Public_Schools.sld' not recognized as a supported file format.