### PR TITLE
Make the data writeable

### DIFF
--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -472,6 +472,13 @@ class OGRImport(Import):
                 for i in range(layer_definition.GetFieldCount()):
 
                     field_def = layer_definition.GetFieldDefnRef(i)
+                    field_name = field_def.GetName()
+                    try:
+                        field_name = field_name.decode('utf-8')
+                    except UnicodeDecodeError as e:
+                        logger.error('Error Decoding {} - {}'.format(field_name,
+                                                                     str(e)))
+                        field_def.SetName(str(field_name.decode('utf-8', 'ignore')))
 
                     if field_def.GetName() == target_layer.GetFIDColumn() and field_def.GetType() != 0:
                         field_def.SetType(0)

--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -148,7 +148,8 @@ class GDALInspector(InspectorMixin):
         open_options = kwargs.get('open_options', [])
 
         try:
-            self.data = gdal.OpenEx(filename, open_options=open_options)
+            # "1" argument makes the data writeable
+            self.data = gdal.OpenEx(filename, 1, open_options=open_options)
         except:
             msg = 'gdal.OpenEx({}, {}) failed.'.format(filename, open_options)
             logger.debug(msg)


### PR DESCRIPTION
This PR addresses the issue where field names can fail utf-8 decoding. If decoding fails, it ignores the invalid characters and updates the field name prior to creating the field on the target layer.